### PR TITLE
Demonstrate manual references with BibTex

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -9,6 +9,8 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 
 Manubot makes it easy to cite this manuscript [@url:https://manubot.github.io/try-manubot/].
 It has been used to write several manuscripts that are now preprints on _bioRxiv_ [@doi:10.1101/474403; @doi:10.1101/515940; @doi:10.1101/502484; @doi:10.1101/654566].
+Notice that only [@doi:10.1101/502484] has the correct name of the preprint server.
+Manubot allows authors to overwrite reference information, in this case with a BibTeX file.
 
 Lorem ipsum also makes a strong conclusion.
 

--- a/content/manual-references.bib
+++ b/content/manual-references.bib
@@ -1,0 +1,13 @@
+@article{doi:10.1101/502484,
+	title = {Scaling tree-based automated machine learning to biomedical big data with a dataset selector},
+	copyright = {© 2018, Posted by Cold Spring Harbor Laboratory. This pre-print is available under a Creative Commons License (Attribution 4.0 International), CC BY 4.0, as described at http://creativecommons.org/licenses/by/4.0/},
+	url = {https://www.biorxiv.org/content/10.1101/502484v1},
+	doi = {10.1101/502484},
+	language = {en},
+	urldate = {2019-06-04},
+	journal = {bioRxiv},
+	author = {Le, Trang T. and Fu, Weixuan and Moore, Jason H.},
+	month = dec,
+	year = {2018},
+	pages = {502484}
+}


### PR DESCRIPTION
Following up on https://github.com/manubot/manubot/pull/104#pullrequestreview-238865237.  I have not yet tested a local build.  I created the `.bib` file via export from Zotero.

_Edit: we can wait to merge this until after pulling in https://github.com/manubot/rootstock/pull/227 with the updated `manubot process` command_